### PR TITLE
graceful shutdownの導入

### DIFF
--- a/api-server/controllers/article_controller.go
+++ b/api-server/controllers/article_controller.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/ShinnosukeSuzuki/practice-golang-api/apperrors"
 	"github.com/ShinnosukeSuzuki/practice-golang-api/common"
@@ -27,6 +28,7 @@ func NewArticleController(s services.ArticleServicer) *ArticleController {
 // ハンドラメソッドを定義
 // GET /hello
 func (c *ArticleController) HelloHandler(w http.ResponseWriter, r *http.Request) {
+	time.Sleep(10 * time.Second)
 	io.WriteString(w, "Hello, world!\n")
 }
 

--- a/api-server/main.go
+++ b/api-server/main.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
 
 	"github.com/ShinnosukeSuzuki/practice-golang-api/api"
 
@@ -30,6 +35,40 @@ func main() {
 	// コントローラ型MyAppControllerのハンドラメソッドとパスを紐付け
 	r := api.NewRouter(db)
 
+	// シグナルを受け取るためのコンテキストを作成
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, os.Interrupt, os.Kill)
+	defer stop()
+
 	log.Println("server start at :8080")
-	log.Fatal(http.ListenAndServe(":8080", r))
+	srv := &http.Server{
+		Addr:    ":8080",
+		Handler: r,
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+
+	go func() {
+		// シグナルを受け取るまで待機
+		<-ctx.Done()
+
+		// 5秒のタイムアウト付きコンテキストを作成
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+
+		// サーバーをシャットダウン(新しい接続の受け付けを停止し、contextがキャンセルされたら終了する)
+		if err := srv.Shutdown(ctx); err != nil {
+			log.Fatalf("Shutdown(): %v", err)
+		}
+		defer wg.Done()
+	}()
+
+	// 正常にシャットダウンした場合はhttp.ErrServerClosedが返る
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("ListenAndServe(): %v", err)
+	}
+
+	wg.Wait()
+
 }


### PR DESCRIPTION
検証
`/hello`のハンドラーをレスポンスを返すように10秒かかるように変更した。
1つのpostmanで`/hello`にリクエストして、その後にgo run main.goを^Cでキャンセルする。
その後にもう1つのpostmanで同様のリクエストをする。
この時、2つ目のリクエストに対してはレスポンスを返さずに、1つ目のリクエストに対してレスポンスを返した後に直ちにサーバーがシャットダウンすることを確認した。